### PR TITLE
Removed unused root user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ LABEL repository="https://github.com/dependency-check/Dependency-Check_Action" \
       com.github.actions.icon="shield" \
       com.github.actions.color="red"
 
-USER root 
-
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/bin/sh","/entrypoint.sh"]
+COPY entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+ENTRYPOINT ["/bin/sh","/opt/entrypoint.sh"]


### PR DESCRIPTION
Fixing the issue as described here: https://github.com/dependency-check/Dependency-Check_Action/issues/22

Removing unused root user.
Modifying path of the entrypoint to /opt instead.

Verified locally that the image still runs through the entrypoint.

Please let me know if it looks good and/or if any checks in CI can be run.